### PR TITLE
Bugfix: Typo in commands-fallback-allowed

### DIFF
--- a/src/utils/commands.jl
+++ b/src/utils/commands.jl
@@ -141,7 +141,7 @@ function Command(;
 
     # Run the fallbacks on the message itself.
     wrapped_fb_parsers(c::Client, e::MessageCreate) = fallback_parsers(c, e.message)
-    wrapped_fb_allowed(c::Client, e::MessageCreate) = falback_allowed(c, e.message)
+    wrapped_fb_allowed(c::Client, e::MessageCreate) = fallback_allowed(c, e.message)
     wrapped_fb_permissions(c::Client, e::MessageCreate) = fallback_permissions(c, e.message)
     wrapped_fb_cooldown(c::Client, e::MessageCreate) = fallback_cooldown(c, e.message)
 


### PR DESCRIPTION
Caused an error when a vector of allowed users was used for a command, and a user without access tried to invoke it, because the function was spelled incorrectly and could not be resolved.

What have you changed?

* [ ] Added a new feature
* [ x ] Fixed a reported issue (which one?)
* [ ] Updated documentation

If you're adding a new feature, please ensure that you take care of the following items:

* [ ] Add unit tests if applicable
* [ ] Document new or changed functionality
* [ ] Add an example to the `examples/` directory if the feature is sufficiently large, or below otherwise
