### PR TITLE
fix to `premium_since::OptionalNullable{DateTime}`

### DIFF
--- a/examples/commands.jl
+++ b/examples/commands.jl
@@ -6,7 +6,7 @@ using Discord
 
 function main()
     c = Client(ENV["DISCORD_TOKEN"])
-    add_command!(c, r"^echo (.+)") do c, msg, noprefix
+    add_command!(c, :echo; pattern=r"^echo (.+)") do c, msg, noprefix
         reply(c, msg, noprefix)
     end
     open(c)

--- a/src/types/member.jl
+++ b/src/types/member.jl
@@ -9,7 +9,7 @@ struct Member
     nick::OptionalNullable{String}  # Not supposed to be nullable.
     roles::Vector{Snowflake}
     joined_at::DateTime
-    premium_since::Optional{DateTime}
+    premium_since::OptionalNullable{DateTime}
     deaf::Bool
     mute::Bool
 end


### PR DESCRIPTION
What have you changed?
* [x] Fixed a reported issue (which one?) #17 

I got the similar error.
```
~/.julia/dev/Discord/examples $ julia commands.jl
┌ Info: Logged in as test-bot
│   time = 2019-11-10T00:25:24.003
└   conn = 1
┌ Error: Parsing failed
│   time = 2019-11-10T00:25:25.428
│   conn = 1
│   T = Discord.GuildCreate
│   exception =
│    MethodError: no method matching datetime(::Nothing)
│    Closest candidates are:
│      datetime(::Dates.DateTime) at /Users/wookyoung/.julia/dev/Discord/src/types/types.jl:19
│      datetime(::Int64) at /Users/wookyoung/.julia/dev/Discord/src/types/types.jl:17
│      datetime(::AbstractString) at /Users/wookyoung/.julia/dev/Discord/src/types/types.jl:18
│    Stacktrace:
│     [1] #(globalref #<julia: Discord> Member)#279(::Base.Iterators.Pairs{Symbol,Any,NTuple{8,Symbol},NamedTuple{(:nick, :user, :premium_since, :joined_at, :roles, :deaf, :hoisted_role, :mute),Tuple{Nothing,Dict{Symbol,Any},Nothing,String,Array{Any,1},Bool,Nothing,Bool}}}, ::Type{Discord.Member}) at /Users/wookyoung/.julia/dev/Discord/src/types/types.jl:97
│     [2] (::Core.var"#kw#Type")(::NamedTuple{(:nick, :user, :premium_since, :joined_at, :roles, :deaf, :hoisted_role, :mute),Tuple{Nothing,Dict{Symbol,Any},Nothing,String,Array{Any,1},Bool,Nothing,Bool}}, ::Type{Discord.Member}) at ./none:0
│     [3] Discord.Member(::Dict{Symbol,Any}) at /Users/wookyoung/.julia/dev/Discord/src/types/types.jl:98
│     [4] _broadcast_getindex_evalf at ./broadcast.jl:630 [inlined]
│     [5] _broadcast_getindex at ./broadcast.jl:603 [inlined]
│     [6] getindex at ./broadcast.jl:563 [inlined]
│     [7] macro expansion at ./broadcast.jl:909 [inlined]
│     [8] macro expansion at ./simdloop.jl:77 [inlined]
│     [9] copyto! at ./broadcast.jl:908 [inlined]
│     [10] copyto! at ./broadcast.jl:863 [inlined]
│     [11] copy at ./broadcast.jl:839 [inlined]
│     [12] materialize at ./broadcast.jl:819 [inlined]
```

fix also `examples/commands.jl`