### PR TITLE
Fix helper tests

### DIFF
--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -11,11 +11,11 @@
         @test string(u) == "<@255>"
         @test string(e1) == "<:foo:255>"
         @test string(e2) == "foo"
-        m = Member(u, "foo", [], now(), true, true)
+        m = Member(u, "foo", [], now(), missing, true, true)
         @test string(m) == "<@!255>"
-        m = Member(u, nothing, [], now(), true, true)
+        m = Member(u, nothing, [], now(), missing, true, true)
         @test string(m) == string(u)
-        m = Member(u, missing, [], now(), true, true)
+        m = Member(u, missing, [], now(), missing, true, true)
         @test string(m) == string(u)
         # Make sure that string interpolation works normally (julia#21982).
         @test "$u" == string(u)


### PR DESCRIPTION
Unit tests were failing due to new field added to Member. Updated tests to set new field to `missing`.