### PR TITLE
Fix typo: kwargs... to kwargs

### DIFF
--- a/src/rest/endpoints/channel.jl
+++ b/src/rest/endpoints/channel.jl
@@ -201,7 +201,7 @@ Delete multiple [`Message`](@ref)s.
 More details [here](https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages).
 """
 function bulk_delete_messages(c::Client, channel::Integer; kwargs...)
-    return Response(c, :POST, "/channels/$channel/messages/bulk-delete"; body=kwargs...)
+    return Response(c, :POST, "/channels/$channel/messages/bulk-delete"; body=kwargs)
 end
 
 """


### PR DESCRIPTION
This has always been an error but has changed to be a parse error instead of a runtime error in Julia nightly (see https://github.com/JuliaLang/julia/issues/33250).