### PR TITLE
fix: remove extra `end` under `main` function

### DIFF
--- a/examples/pingpong.jl
+++ b/examples/pingpong.jl
@@ -17,8 +17,6 @@ function main()
     return client
 end
 
-end
-
 if abspath(PROGRAM_FILE) == @__FILE__
     client = Ping.main()
     wait(client)


### PR DESCRIPTION
What have you changed?

* [ ] Added a new feature
* [ ] Fixed a reported issue (which one?)
* [ ] Updated documentation
* [x] Fix a small error

There was an extra `end` under the `main` function in the `pingpong.jl` function, so I removed it.