### PR TITLE
Unification of examples

### DIFF
--- a/examples/pingpong.jl
+++ b/examples/pingpong.jl
@@ -2,24 +2,24 @@ module Ping
 
 using Discord
 
-function on_message_create(client::Client, event::MessageCreate)
+function on_message_create(c::Client, event::MessageCreate)
     if event.message.content == "ping"
-       reply(client, event.message, "Pong!")    
+       reply(c, event.message, "Pong!")    
     elseif event.message.content == "pong"   	  
-       reply(client, event.message, "Ping!")
+       reply(c, event.message, "Ping!")
     end
 end
 
 function main()
-    client = Client(ENV["DISCORD_TOKEN"])
-    open(client)
-    add_handler!(client, MessageCreate, on_message_create; tag=:ping)
-    return client
+    c = Client(ENV["DISCORD_TOKEN"])
+    open(c)
+    add_handler!(c, MessageCreate, on_message_create; tag=:ping)
+    return c
 end
 
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__
-    client = Ping.main()
-    wait(client)
+    c = Ping.main()
+    wait(c)
 end


### PR DESCRIPTION
`pingpong.jl` is the only example file that uses `client` instead of `c`

What have you changed?

* [ ] Added a new feature
* [ ] Fixed a reported issue (which one?)
* [ ] Updated documentation

If you're adding a new feature, please ensure that you take care of the following items:

* [ ] Add unit tests if applicable
* [ ] Document new or changed functionality
* [ ] Add an example to the `examples/` directory if the feature is sufficiently large, or below otherwise
