### PR TITLE
Fix split_message

### DIFF
--- a/docs/src/helpers.md
+++ b/docs/src/helpers.md
@@ -5,10 +5,12 @@ CurrentModule = Discord
 # Helpers
 
 ```@docs
+STYLES
 Permission
 has_permission
 permissions_in
 reply
+filter_ranges
 split_message
 plaintext
 upload_file

--- a/src/utils/helpers.jl
+++ b/src/utils/helpers.jl
@@ -186,30 +186,27 @@ end
 """
     filter_ranges(u::Vector{UnitRange{Int}})
 
-Filter a list of ranges, discarding ranges included in others from the list.
+Filter a list of ranges, discarding ranges included in other ranges from the list.
 
 # Example
 ```jldoctest; setup=:(using Discord)
-julia> filter_ranges([1:5, 3:8, 1:20, 2:16, 10:70, 25:60, 5:35, 50:90])
+julia> Discord.filter_ranges([1:5, 3:8, 1:20, 2:16, 10:70, 25:60, 5:35, 50:90, 10:70])
 4-element Vector{UnitRange{Int64}}:
  1:20
- 10:70
  5:35
  50:90
+ 10:70
 ```
 """
 function filter_ranges(u::Vector{UnitRange{Int}})
-    v = Vector{UnitRange{Int}}()
-    while length(u) > 1
-        if all(m -> (u[1] ⊈ m), u[2:end])
-            push!(v, u[1])
+    v = fill(true, length(u))
+    for i in 1:length(u)
+        if !all(m -> (m[1] == i) || (u[i] ⊈ m[2]), 
+                m for m in enumerate(u) if v[m[1]] == true)
+            v[i] = false
         end
-        u = u[findall(m -> m ⊈ u[1], u[2:end]).+1]
     end
-    if length(u) == 1
-        push!(v,u[1])
-    end
-    return v
+    return u[v]
 end
 
 

--- a/src/utils/helpers.jl
+++ b/src/utils/helpers.jl
@@ -16,9 +16,7 @@ export PERM_NONE,
 const CRUD_FNS = :create, :retrieve, :update, :delete
 
 """
-    const STYLES
-
-Define regex expressions for [`split_message`](@ref) not to break Discord formatting.
+Regex expressions for [`split_message`](@ref) to not break Discord formatting.
 """
 const STYLES = [
     r"```.+?```"s, r"`.+?`", r"~~.+?~~", r"(_|__).+?\1", r"(\*+).+?\1",

--- a/src/utils/helpers.jl
+++ b/src/utils/helpers.jl
@@ -277,7 +277,8 @@ function split_message(text::AbstractString; chunk_limit::Int=2000,
             return chunks
         end
         # get ranges associated with the formattings
-        mranges = vcat(findall.(union(STYLES, extrastyles),Ref(text))...)
+        # mranges = vcat(findall.(union(STYLES, extrastyles),Ref(text))...) can't use findall in julia 1.0 and 1.1 ...
+        mranges = [m.offset:m.offset+ncodeunits(m.match)-1 for m in vcat(collect.(eachmatch.(union(STYLES, extrastyles), text))...)]
         # filter ranges to eliminate inner formattings
         franges = filter_ranges(mranges)
         # get ranges that get split apart by the chunk limit - there should be only one, unless text is ill-formatted

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -54,27 +54,38 @@
         
         # Chunks can vary in length limit and still do not break down on nested formattings
         chunks = split_message("**hello**, _*beautiful* **blue**  world_", chunk_limit=25)
-        @test length(chunks) == 2
+        @test length(chunks) == 3
         @test chunks[1] == "**hello**,"
-        @test chunks[2] == "_*beautiful* **blue**  world_"
+        @test chunks[2] == "_*beautiful* **blue**  wo"
+        @test chunks[3] == "rld_"
 
         # Chunks respect unicode
         chunks = split_message("**≡Ηϵλλo** *ωoρλδ≡*", chunk_limit=15)
         @test length(chunks) == 2
         @test chunks[1] == "**≡Ηϵλλo**"
         @test chunks[2] == "*ωoρλδ≡*"       
-        chunks = split_message("Examples\n≡≡≡≡≡≡≡≡\n```julia\njulia> x=1\n1\n```\n", chunk_limit=12)
-        @test length(chunks) == 3
-        @test chunks[1] == "Examples\n≡≡≡"
+        chunks = split_message("**Examples**\n≡≡≡≡≡≡≡≡\n", chunk_limit=16)
+        @test length(chunks) == 2
+        @test chunks[1] == "**Examples**\n≡≡≡"
         @test chunks[2] == "≡≡≡≡≡"
-        @test chunks[3] ==  "```julia\njulia> x=1\n1\n```"
 
         # Chunks respect extra formatting
-        chunks = split_message("Examples\n≡≡≡≡≡≡≡≡\n```julia\njulia> x=1\n1\n```\n", chunk_limit=12, extrastyles = [r"\n≡.+\n", r"n-.+\n"])
-        @test length(chunks) == 3
-        @test chunks[1] == "Examples"
+        chunks = split_message("**Examples**\n≡≡≡≡≡≡≡≡\n", chunk_limit=16, extrastyles = [r"\n≡.+\n", r"n-.+\n"])
+        @test length(chunks) == 2
+        @test chunks[1] == "**Examples**"
         @test chunks[2] == "≡≡≡≡≡≡≡≡"
-        @test chunks[3] == "```julia\njulia> x=1\n1\n```"
+
+        # Chunks without forced splitting
+        chunks = split_message("**hello**, _*beautiful* **blue**  world_", chunk_limit=25, forcesplit=false)
+        @test length(chunks) == 2
+        @test chunks[1] == "**hello**,"
+        @test chunks[2] == "_*beautiful* **blue**  world_"
+        chunks = split_message("A simple assignment\n\n**Examples**\n≡≡≡≡≡≡≡≡\n```julia\njulia> x=[1,2,3]\n1\n```\n", chunk_limit=20, extrastyles = [r"\n≡.+\n", r"n-.+\n"], forcesplit=false)
+        @test length(chunks) == 4
+        @test chunks[1] == "A simple assignment"
+        @test chunks[2] == "**Examples**"
+        @test chunks[3] == "≡≡≡≡≡≡≡≡"
+        @test chunks[4] == "```julia\njulia> x=[1,2,3]\n1\n```"
     end
 
     @testset "plaintext" begin

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -32,6 +32,7 @@
         @test length(chunks) == 2
         @test chunks[2] == "**foobar**"
         chunks = split_message(string(repeat('.', 1995), "```julia\n1 + 1\n```"))
+        @test length(chunks) == 2
         @test chunks[2] == "```julia\n1 + 1\n```"
 
         # Chunks are separated by spaces.
@@ -39,6 +40,41 @@
         @test length(chunks) == 2
         @test chunks[1] == string(repeat('.', 1995), " foo")
         @test chunks[2] == "bar baz"
+
+        # Chunks do not break down on nested formattings
+        chunks = split_message(string(repeat('.', 3985), "**foo __bar__ baz**"))
+        @test length(chunks) == 3
+        @test chunks[3] == "**foo __bar__ baz**"
+
+        # Chunks can vary in length limit
+        chunks = split_message("**hello**, *world*", chunk_limit=10)
+        @test length(chunks) == 2
+        @test chunks[1] == "**hello**,"
+        @test chunks[2] == "*world*"
+        
+        # Chunks can vary in length limit and still do not break down on nested formattings
+        chunks = split_message("**hello**, _*beautiful* **blue**  world_", chunk_limit=25)
+        @test length(chunks) == 2
+        @test chunks[1] == "**hello**,"
+        @test chunks[2] == "_*beautiful* **blue**  world_"
+
+        # Chunks respect unicode
+        chunks = split_message("**≡Ηϵλλo** *ωoρλδ≡*", chunk_limit=15)
+        @test length(chunks) == 2
+        @test chunks[1] == "**≡Ηϵλλo**"
+        @test chunks[2] == "*ωoρλδ≡*"       
+        chunks = split_message("Examples\n≡≡≡≡≡≡≡≡\n```julia\njulia> x=1\n1\n```\n", chunk_limit=12)
+        @test length(chunks) == 3
+        @test chunks[1] == "Examples\n≡≡≡"
+        @test chunks[2] == "≡≡≡≡≡"
+        @test chunks[3] ==  "```julia\njulia> x=1\n1\n```"
+
+        # Chunks respect extra formatting
+        chunks = split_message("Examples\n≡≡≡≡≡≡≡≡\n```julia\njulia> x=1\n1\n```\n", chunk_limit=12, extrastyles = [r"\n≡.+\n", r"n-.+\n"])
+        @test length(chunks) == 3
+        @test chunks[1] == "Examples"
+        @test chunks[2] == "≡≡≡≡≡≡≡≡"
+        @test chunks[3] == "```julia\njulia> x=1\n1\n```"
     end
 
     @testset "plaintext" begin


### PR DESCRIPTION
What have you changed?

* [X] Added a new feature
* [X] Fixed a reported issue (which one?)
* [X] Updated documentation

If you're adding a new feature, please ensure that you take care of the following items:

* [X] Document new or changed functionality
* [X] Add unit tests if applicable
* [ ] Add an example to the `examples/` directory if the feature is sufficiently large, or below otherwise

The changes fix and add features to the `split_message` function:
1) Fix handling unicode characters
2) Fix handling nested formatting
3) Fix backtracking to a valid index
4) Add optional argument to vary the length limit of the chunks, which were hardcoded to Discord's 2000 limit
5) Add optional argument to include extra regex styles formatting.
6) Add a choice of forcing a split or not, since in some edge cases it might not be possible to avoid breaking format.

1-3 were known issues as reported in comments within the `split_message` code. 
6 was apparently not known, but it could happen.
4 is a feature that who knows might be useful.
5 has been very useful in [HoJBot](https://github.com/Humans-of-Julia/HoJBot.jl), used in the [Humans of Julia](https://disboard.org/server/762167454973296644) Discord server, where one of the commands is to parse julia docstring, which adds `≡≡≡≡≡≡≡` and other formatting. So, passing `extrastyles = [r"\n≡.+\n"]` avoids breaking it. This could serve as a good example of this feature.
