### PR TITLE
Make Permission enum use backing type Int64

### DIFF
--- a/src/utils/helpers.jl
+++ b/src/utils/helpers.jl
@@ -26,7 +26,7 @@ const STYLES = [
 Bitwise permission flags.
 More details [here](https://discordapp.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags).
 """
-@enum Permission begin
+@enum Permission::Int64 begin
     PERM_CREATE_INSTANT_INVITE=1<<0
     PERM_KICK_MEMBERS=1<<1
     PERM_BAN_MEMBERS=1<<2


### PR DESCRIPTION
It used to use the default of Int32, which caused a failure during precompilation

What have you changed?

* [ ] Added a new feature
* [x] Fixed a reported issue (which one?)
* [ ] Updated documentation

If you're adding a new feature, please ensure that you take care of the following items:

* [ ] Add unit tests if applicable
* [ ] Document new or changed functionality
* [ ] Add an example to the `examples/` directory if the feature is sufficiently large, or below otherwise
